### PR TITLE
NaN fix DLASCL: parameter number 4 is invalid

### DIFF
--- a/Matlab Version/EigenRec.m
+++ b/Matlab Version/EigenRec.m
@@ -33,6 +33,7 @@ function [ Pi, dt ] = EigenRec( R, f, d )
 
 % Example using the Cosine Similarity Matrix (see our paper for details)
 W = R*diag(diag(sparse(diag(sqrt(diag(R'*R)))).^(d-1))); % The inter-item similarity matrix A_cos = W'*W
+W(isnan(W))=0;
 [n,m] = size(W);
 OPTS.issym = 1; OPTS.tol = 1e-8;
 tic


### PR DESCRIPTION
In some situations and different sized datasets.
It gives an error;

�DLASCL: parameter number 4 is invalid
error: Fortran procedure terminated by call to XERBLA
error: called from
    eigs at line 285 column 20

This minor fix alleviating the problem.

Nice paper, nice job.
Thanks, Athanasios.